### PR TITLE
Fix empty redis issue in Scheduled

### DIFF
--- a/lib/lita/timing/scheduled.rb
+++ b/lib/lita/timing/scheduled.rb
@@ -18,7 +18,7 @@ module Lita
           next_run = calc_next_daily_run(time, days, last_run_at)
           if next_run < Time.now
             yield
-            @redis.set(@name, Time.now.to_i, ex: ONE_WEEK_IN_SECONDS * 2)
+            set_last_run_at
           end
         end
       end
@@ -29,7 +29,7 @@ module Lita
           next_run = calc_next_weekly_run(time, day, last_run_at)
           if next_run < Time.now
             yield
-            @redis.set(@name, Time.now.to_i, ex: ONE_WEEK_IN_SECONDS * 2)
+            set_last_run_at
           end
         end
       end
@@ -64,7 +64,12 @@ module Lita
 
       def get_last_run_at
         value = @redis.get(@name)
-        value ? Time.at(value.to_i).utc : Time.now.utc
+        value ? Time.at(value.to_i).utc : set_last_run_at
+      end
+
+      def set_last_run_at(time = Time.now.utc)
+        @redis.set(@name, time.to_i, ex: ONE_WEEK_IN_SECONDS * 2)
+        time
       end
     end
   end

--- a/lib/lita/timing/time_parser.rb
+++ b/lib/lita/timing/time_parser.rb
@@ -22,7 +22,7 @@ module Lita
       end
 
       def self.extract_hours_and_minutes(string)
-        _, hours, minutes = *string.match(/\A(\d\d):(\d\d)\Z/)
+        _, hours, minutes = *string.match(/\A(\d{1,2}):(\d{2})\Z/)
         if hours.nil? || minutes.nil?
           raise ArgumentError, "time should be HH:MM"
         end

--- a/spec/time_parser_spec.rb
+++ b/spec/time_parser_spec.rb
@@ -67,6 +67,13 @@ RSpec.describe Lita::Timing::TimeParser do
         expect(result).to eq([23,59])
       end
     end
+    context "with H:MM format" do
+      let(:input) { "1:23" }
+
+      it "returns correct values" do
+        expect(result).to eq([1,23])
+      end
+    end
     context "with invalid string" do
       let(:input) { "Foo" }
 


### PR DESCRIPTION
There was an issue in the Scheduled module when running `daily_at` or
`weekly_at` for the first time that would prevent an event from _ever_
being scheduled.

The solution is to set the `last_run_at` value if it doesn't exist in
redis.
